### PR TITLE
Sorting output from os.listdir when reading situation files

### DIFF
--- a/src/trafficgen/read_files.py
+++ b/src/trafficgen/read_files.py
@@ -20,7 +20,7 @@ def read_situation_files(situation_folder: Path) -> List[Situation]:
         situations: List of desired traffic situations
     """
     situations: List[Situation] = []
-    for file_name in [file for file in os.listdir(situation_folder) if file.endswith(".json")]:
+    for file_name in sorted([file for file in os.listdir(situation_folder) if file.endswith(".json")]):
         file_path = os.path.join(situation_folder, file_name)
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)


### PR DESCRIPTION
As per the [docs](https://docs.python.org/3/library/os.html#os.listdir) for `os.listdir`:

> Return a list containing the names of the entries in the directory given by path. **The list is in arbitrary order**, and does not include the special entries '.' and '..' even if they are present in the directory. If a file is removed from or added to the directory during the call of this function, whether a name for that file be included is unspecified.

The output is in arbitrary order and actually depends on the filesystem. This makes it difficult to recreate the baseline encounter set from the input since the numbering of the generated files will not match the ordering of the input files.

Sorting the output from `os.listdir` fixes this issue.