### PR TITLE
Add test for non-default paths for cli, fix issues in reading of files related to that.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
--/-
+* Fix issue with file reading when using non-default paths, and add test for it.
 
 ## [0.7.2] - 2025-03-14
 
@@ -31,13 +31,11 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 * Updating workflows
 * Removed maxSpeed from the output files generated using the tool
 
-
 ## [0.6.0] - 2024-11-11
 
 ### Changed
 
 * Updated to download-artifact@v4  (from download-artifact@v3)
-
 
 ## [0.5.0] - 2024-04-26
 
@@ -45,7 +43,6 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 * removed specific names for target ships. Files generated with target ship 1, 2 etc.
 * changed tests. Still need to figure out why some tests "fail" using CLI.
-
 
 ## [0.4.0] - 2024-04-19
 
@@ -57,7 +54,6 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
   is not just a number, but could also be a range
 * situation length is used when checking if target ship is passing land
 
-
 ## [0.3.0] - 2024-04-10
 
 ### Changed
@@ -65,7 +61,6 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 * using types from maritime schema
 * lat/lon used instead of north/east
 * the generated output files are using "maritime" units: knots and degrees
-
 
 ## [0.2.0] - 2024-01-11
 
@@ -81,11 +76,9 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 * removed cyclic import
 * length of encounter may be specified by user
 
-
 ## [0.1.0] - 2023-11-08
 
 * First release on PyPI.
-
 
 <!-- Markdown link & img dfn's -->
 [0.6.0]: https://github.com/dnv-opensource/ship-traffic-generator/releases/tag/v0.6.0
@@ -93,4 +86,3 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 [0.4.0]: https://github.com/dnv-opensource/ship-traffic-generator/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dnv-opensource/ship-traffic-generator/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dnv-opensource/ship-traffic-generator/releases/tag/v0.2.0
-[trafficgen]: https://github.com/dnv-opensource/ship-traffic-generator

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -15,7 +15,7 @@ The command line tool takes different input options::
     -s, --situations PATH          Folders with situations (default=./baseline_situations_input/)
     -t, --targets PATH             Folder with target configurations (default=./target_ships/)
     -c, --settings PATH            Path to settings file (default=./settings/encounter_settings.json)
-    --visualize                    Plot visualization
+    -v, --visualize                Plot visualization
     --col INTEGER                  Number of columns for plot, may be used with visualize (default=10)
     --row INTEGER                  Number of rows for plot, may be used with visualize (default=6)
     --visualize-situation INTEGER  Plot individual traffic situation, specify INTEGER value

--- a/src/trafficgen/read_files.py
+++ b/src/trafficgen/read_files.py
@@ -31,9 +31,9 @@ def read_situation_files(situation_folder: Path) -> list[SituationInput]:
         List of desired traffic situations
     """
     situations: list[SituationInput] = []
+    print(f"Reading traffic situation input files from: {situation_folder}")
     for file_name in sorted([file for file in Path.iterdir(situation_folder) if str(file).endswith(".json")]):
-        file_path = situation_folder / file_name
-        with Path.open(file_path, encoding="utf-8") as f:
+        with Path.open(file_name, encoding="utf-8") as f:
             data = json.load(f)
 
         data = convert_keys_to_snake_case(data)
@@ -206,6 +206,7 @@ def read_own_ship_static_file(own_ship_static_file: Path) -> ShipStatic:
     own_ship : ShipStatic
         Own_ship static information
     """
+    print(f"Reading own ship static file from: {own_ship_static_file}")
     with Path.open(own_ship_static_file, encoding="utf-8") as f:
         data = json.load(f)
     data = convert_keys_to_snake_case(data)
@@ -236,10 +237,10 @@ def read_target_ship_static_files(target_ship_folder: Path) -> list[ShipStatic]:
     """
     target_ships_static: list[ShipStatic] = []
     i = 0
+    print(f"Reading target ship static files from: {target_ship_folder}")
     for file_name in sorted([file for file in Path.iterdir(target_ship_folder) if str(file).endswith(".json")]):
         i = i + 1
-        file_path = target_ship_folder / file_name
-        with Path.open(file_path, encoding="utf-8") as f:
+        with Path.open(file_name, encoding="utf-8") as f:
             data = json.load(f)
         data = convert_keys_to_snake_case(data)
 
@@ -289,6 +290,7 @@ def read_encounter_settings_file(settings_file: Path) -> EncounterSettings:
     encounter_settings : EncounterSettings
         Settings for the encounter
     """
+    print(f"Reading encounter settings file from: {settings_file}")
     with Path.open(settings_file, encoding="utf-8") as f:
         data = json.load(f)
     encounter_settings: EncounterSettings = EncounterSettings(**data)

--- a/tests/test_trafficgen.py
+++ b/tests/test_trafficgen.py
@@ -90,6 +90,7 @@ def test_gen_situations(
     )
     assert len(situations) == 55
 
+
 def test_gen_situations_cli_nondefault_folders(
     situations_folder: Path,
     own_ship_file: Path,

--- a/tests/test_trafficgen.py
+++ b/tests/test_trafficgen.py
@@ -90,6 +90,35 @@ def test_gen_situations(
     )
     assert len(situations) == 55
 
+def test_gen_situations_cli_nondefault_folders(
+    situations_folder: Path,
+    own_ship_file: Path,
+    settings_file: Path,
+    output_folder: Path,
+):
+    """Test generating traffic situations using the cli, using a non-default target ship folder."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "gen-situation",
+            "-s",
+            "data/baseline_situations_input",
+            "-os",
+            str(own_ship_file),
+            "-t",
+            "data/target_ships",
+            "-c",
+            str(settings_file),
+            "-o",
+            str(output_folder),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Generating traffic situations" in result.output
+    assert "Plotting traffic situations" not in result.output
+    assert "Writing traffic situations to files" in result.output
+
 
 def test_gen_situations_1_ts_full_spec_cli(
     situations_folder_test_01: Path,


### PR DESCRIPTION
Resolves #52 

One way to test this, is to use this branch and run pytest, and then check against having the old code in read_files.py (see commit changes). 

Another way to test is to use the main branch and this branch, and try the same command for reading the situation and target ship files from somewhere else on the system, and it will bomb on main (see issue description).